### PR TITLE
Updated visual cap

### DIFF
--- a/android/conf/single.conf.js
+++ b/android/conf/single.conf.js
@@ -11,7 +11,7 @@ exports.capabilities = {
 		"plugin": "node_js-mocha",
         "platformName" : "android",
         "deviceName" : "Pixel.*",
-        "platformversion": "15",
+        "platformVersion": "15",
         "isRealMobile": true,
         "build": "testRun",
         "name": "sampleTest",

--- a/android/conf/single.conf.js
+++ b/android/conf/single.conf.js
@@ -16,7 +16,6 @@ exports.capabilities = {
         "build": "testRun",
         "name": "sampleTest",
         "appium:app" : "lt://APP10160521601750440880142826",
-        "network": true,
-        "visual": true
+        "network": true
 	}
 };

--- a/android/conf/single.conf.js
+++ b/android/conf/single.conf.js
@@ -16,5 +16,7 @@ exports.capabilities = {
         "build": "testRun",
         "name": "sampleTest",
         "appium:app" : "lt://APP10160521601750440880142826",
+        "network": true,
+        "visual": true
 	}
 };


### PR DESCRIPTION
updated visual cap in LT cap 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a property name error in Android test configuration and adds a new network flag. The changes improve test reliability and connectivity during test execution. These configuration enhancements contribute to more robust Android testing.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>